### PR TITLE
use thread config for arsd

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,10 +91,7 @@ I've tried at least make response sizes to be of the same size for all the tests
 
 ##### [arsd-official](https://code.dlang.org/packages/arsd-official)
 
-I've wanted to add this popular library in the mix just for comparison, but test is currently disabled as it doesn't scale at all.
-It doesn't use eventloop but just preforked processes or limited thread pool and is possible to use only with a limited number of concurrent clients with own server implementation.
-
-Sorry @adamdruppe.
+I've wanted to add this popular library in the mix just for comparison.
 
 ##### [eventcore](https://github.com/vibe-d/eventcore)
 

--- a/dlang/arsd/app.d
+++ b/dlang/arsd/app.d
@@ -1,7 +1,9 @@
 #!/bin/env dub
 /+ dub.sdl:
     name "app"
-    dependency "arsd-official:cgi" version=">=8.4.3"
+    dependency "arsd-official:cgi" version=">=8.4.4"
+    // the threads version works better on benchmarks due to various tradeoffs
+    subConfiguration "arsd-official:cgi" "embedded_httpd_threads"
 +/
 
 // import std;

--- a/dlang/arsd/meta.json_
+++ b/dlang/arsd/meta.json_
@@ -4,7 +4,7 @@
         "category": "platform",
         "buildCmd": ["dub", "build", "--single", "app.d"],
         "buildEnv": {
-            "DFLAGS": "--d-version=embedded_httpd"
+            "DFLAGS": "--d-version=embedded_httpd_threads"
         },
         "runCmd": ["./app", "--port", "8080"]
     }


### PR DESCRIPTION
I didn't even offer this config on dub before so I had to bump the version too.

I couldn't actually run the benchmark since I don't have docker, so it might still not work, but nevertheless, your other notes in the readme are false anyway. If it still doesn't work, it is ok to note that, but jumping from "didn't work in this specific benchmark" to the other stuff written there is inaccurate. (it is just more complicated than that, like it can even use an event loop in some cases and while the thread pool is currently hard-coded at 16 - which should prolly be changed, that number is just what happens to work well on my computer - this doesn't necessarily limit anything. having too many threads can actually be worse on scalability than having too few.)