### PR TITLE
add experimental hybrid based on arsd master

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,10 +96,11 @@ Epoll and io_uring are added. Both named as `raw`.
 
 ##### [arsd-official](https://code.dlang.org/packages/arsd-official)
 
-I've wanted to add this popular library in the mix just for comparison. Currently two configurations of internal http servers are used:
+I've wanted to add this popular library in the mix just for comparison. Currently three configurations of internal http servers are used:
 
 * process - forked process, each serving one request
 * threads - threadpool to handle connected clients
+* hybrid - an experimental Linux-only hybrid implementation of forked processes, worker threads, and fibers in an event loop
 
 They are added to a `singeCore` type tests as they don't use (at the moment) some eventloop so we can compare this traditional way against the others in that category.
 

--- a/dlang/arsd/dub.sdl
+++ b/dlang/arsd/dub.sdl
@@ -1,6 +1,6 @@
 name "app"
 targetType "executable"
-dependency "arsd-official:cgi" version=">=8.4.4"
+dependency "arsd-official:cgi" version="~master"
 
 configuration "threads" {
     // the threads version works better on benchmarks due to various tradeoffs
@@ -9,4 +9,8 @@ configuration "threads" {
 
 configuration "processes" {
     subConfiguration "arsd-official:cgi" "embedded_httpd_processes"
+}
+
+configuration "hybrid" {
+    subConfiguration "arsd-official:cgi" "embedded_httpd_hybrid"
 }

--- a/dlang/arsd/dub.selections.json
+++ b/dlang/arsd/dub.selections.json
@@ -1,6 +1,6 @@
 {
 	"fileVersion": 1,
 	"versions": {
-		"arsd-official": "8.4.4"
+		"arsd-official": "~master"
 	}
 }

--- a/dlang/arsd/meta.json
+++ b/dlang/arsd/meta.json
@@ -12,5 +12,13 @@
         "category": "platform",
         "buildCmd": ["dub", "build", "-c", "processes"],
         "runCmd": ["./app", "--port", "8080"]
+    },
+    {
+        "name": "hybrid",
+        "type": "singleCore",
+        "category": "platform",
+        "buildCmd": ["dub", "build", "-c", "hybrid"],
+        "runCmd": ["./app", "--port", "8080"]
     }
+
 ]


### PR DESCRIPTION
I slapped together this hybrid after thinking about it a bit in the blog Friday. It isn't fully tested but does OK so far so I thought it might be fun to add here and see how it stacks up.

I also fixed an old buffering bug in my write function that harmed performance across the board (it did buffering with the concat operator, already an inefficient way to do it.... but then ignored the buffer and wrote the pieces in a loop anyway, leading to like 8 syscalls when only one was necessary! This killed performance in the hello world case, fixing that helped the existing things a lot too.)

I'll be quite amused if it moves up to the middle of the pack with less than one day's work and no api change :)